### PR TITLE
Fix: the items created from the loot pool are now being added to the ItemManager.

### DIFF
--- a/behaviors/npc/lootable.js
+++ b/behaviors/npc/lootable.js
@@ -38,6 +38,7 @@ module.exports = {
 
       items.forEach(item => {
         item.hydrate(state);
+        state.ItemManager.add(item);
         corpse.addItem(item);
       });
       room.addItem(corpse);


### PR DESCRIPTION
Creating an item in the game seems to be a 3-step process:
- item = ItemFactory.create()
- item.hydrate()
- ItemManager.add(item)
However, that last step was left out.  The other thing to note is that the corpse created is an item that is also being added to the ItemManager, but the add() method is not recursive, adding anything from the corpse's inventory.  Perhaps that could be a future failsafe.